### PR TITLE
DNN-9094 change save settings to be fire and forget

### DIFF
--- a/src/Modules/UI/Dnn.PersonaBar.UI/admin/personaBar/scripts/main.js
+++ b/src/Modules/UI/Dnn.PersonaBar.UI/admin/personaBar/scripts/main.js
@@ -149,50 +149,44 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
                 parentBody.style.overflow = "auto";
                 body.style.overflow = "hidden";
 
-                function closeCallback() {
-                    inAnimation = true;
-                    $personaBarPlaceholder.hide();
-                    self.leaveCustomModules();
-                    var $activePanel = $('#' + utility.getPanelIdFromPath(activePath));
-                    $activePanel.animate({ left: -860 }, 189, 'linear', function () {
-                        $('.socialpanel').css({ left: -860 }).hide();
-                        $mask.animate({
-                            opacity: 0.0
-                        }, 200, function () {
-                            $iframe.width(personaBarMenuWidth);
+                inAnimation = true;
+                $personaBarPlaceholder.hide();
+                self.leaveCustomModules();
+                var $activePanel = $('#' + utility.getPanelIdFromPath(activePath));
+                $activePanel.animate({ left: -860 }, 189, 'linear', function () {
+                    $('.socialpanel').css({ left: -860 }).hide();
+                    $mask.animate({
+                        opacity: 0.0
+                    }, 200, function () {
+                        $iframe.width(personaBarMenuWidth);
 
-                            // for mobile pad device...
-                            if (onTouch) {
-                                iframe.style["min-width"] = "0";
-                                iframe.style.position = "fixed";
-                            }
+                        // for mobile pad device...
+                        if (onTouch) {
+                            iframe.style["min-width"] = "0";
+                            iframe.style.position = "fixed";
+                        }
 
-                            $mask.css("display", "none");
-                            $showSiteButton.hide();
-                            activePath = null;
-                            inAnimation = false;
-                            $(document).unbind('keyup');
+                        $mask.css("display", "none");
+                        $showSiteButton.hide();
+                        activePath = null;
+                        inAnimation = false;
+                        $(document).unbind('keyup');
 
-                            eventEmitter.emitClosePanelEvent();
+                        eventEmitter.emitClosePanelEvent();
 
-                            if (typeof callback === 'function') {
-                                callback();
-                            }
-                        });
+                        if (typeof callback === 'function') {
+                            callback();
+                        }
                     });
-                };
+                });
 
-                if (keepSelection) {
-                    closeCallback();
-                } else {
-                    self.persistent.save({
+                if (!keepSelection) {
+                    saveUserSetting({
                         expandPersonaBar: false
-                    }, closeCallback);
+                    });
                 }
             },
             loadPanel: function handleLoadPanel(identifier, params) {
-                var savePersistentCallback;
-
                 if (inAnimation) return;
 
                 var $menuItem = $('ul.personabarnav').find('[id="' + identifier + '"]');
@@ -261,48 +255,46 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
                 var template = path;
 
                 if ($mask.css("display") === 'none') {
-                    savePersistentCallback = function () {
-                        activePath = path;
-                        activemodule = moduleName;
-                        eventEmitter.emitOpenPanelEvent();
+                    activePath = path;
+                    activemodule = moduleName;
+                    eventEmitter.emitOpenPanelEvent();
 
-                        iframe.style.width = "100%";
-                        parentBody.style.overflow = "hidden";
-                        body.style.overflow = 'auto';
+                    iframe.style.width = "100%";
+                    parentBody.style.overflow = "hidden";
+                    body.style.overflow = 'auto';
 
-                        // for mobile pad device...
-                        if (onTouch) {
-                            iframe.style["min-width"] = "1245px";
-                            iframe.style.position = "fixed";
-                        }
+                    // for mobile pad device...
+                    if (onTouch) {
+                        iframe.style["min-width"] = "1245px";
+                        iframe.style.position = "fixed";
+                    }
 
-                        $mask.css("display", "block");
-                        inAnimation = true;
-                        $mask.animate({
-                            opacity: 0.85
-                        }, 200, function () {
-                            $panel.show().delay(100).animate({ left: personaBarMenuWidth }, 189, 'linear', function () {
-                                inAnimation = false;
-                                $personaBarPlaceholder.show();
-                                self.loadTemplate(folderName, template, $panel, params, function () {
-                                    self.panelLoaded(params);
-                                });
-                                $(document).keyup(function (e) {
-                                    if (e.keyCode === 27) {
-                                        e.preventDefault();
-                                        if (!window.dnn.stopEscapeFromClosingPB) {
-                                            util.closePersonaBar(null, true);
-                                        }
+                    $mask.css("display", "block");
+                    inAnimation = true;
+                    $mask.animate({
+                        opacity: 0.85
+                    }, 200, function () {
+                        $panel.show().delay(100).animate({ left: personaBarMenuWidth }, 189, 'linear', function () {
+                            inAnimation = false;
+                            $personaBarPlaceholder.show();
+                            self.loadTemplate(folderName, template, $panel, params, function () {
+                                self.panelLoaded(params);
+                            });
+                            $(document).keyup(function (e) {
+                                if (e.keyCode === 27) {
+                                    e.preventDefault();
+                                    if (!window.dnn.stopEscapeFromClosingPB) {
+                                        util.closePersonaBar(null, true);
                                     }
-                                });
+                                }
                             });
                         });
-                    };
+                    });
 
-                    self.persistent.save({
+                    saveUserSetting({
                         expandPersonaBar: true,
                         activeIdentifier: identifier
-                    }, savePersistentCallback);
+                    });
 
                 } else {
                     if (activePath !== path) {
@@ -311,18 +303,17 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
                         $activePanel.fadeOut("fast", function handleHideCurrentPanel() {
                             $panel.css({ left: personaBarMenuWidth }).fadeIn("fast", function handleShowSelectedPanel() {
 
-                                savePersistentCallback = function () {
-                                    activePath = path;
-                                    activemodule = moduleName;
-                                    inAnimation = false;
-                                    self.loadTemplate(folderName, template, $panel, params, function () {
-                                        self.panelLoaded(params);
-                                    });
-                                };
-                                self.persistent.save({
+                                activePath = path;
+                                activemodule = moduleName;
+                                inAnimation = false;
+                                self.loadTemplate(folderName, template, $panel, params, function () {
+                                    self.panelLoaded(params);
+                                });
+
+                                saveUserSetting({
                                     expandPersonaBar: true,
                                     activeIdentifier: identifier
-                                }, savePersistentCallback);
+                                });
                             });
                         });
                     } else if (activemodule !== moduleName) {
@@ -484,12 +475,16 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
             return config.siteRoot || "/";
         }
 
-        function saveBtnEditSettings(callback) {
-            util.persistent.save({
+        function saveBtnEditSettings() {
+            saveUserSetting({
                 expandPersonaBar: false,
                 activePath: null,
                 activeIdentifier: null
-            }, callback);
+            });
+        }
+
+        function saveUserSetting(settings) {
+            util.persistent.save(settings);
         }
 
         function inLockEditMode() {
@@ -882,10 +877,9 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
                                                 window.parent.location.reload();
                                             });
                                         };
-                                        util.closePersonaBar(function() {
-                                            saveBtnEditSettings(function() {
-                                                toogleUserMode('EDIT');
-                                            });
+                                        util.closePersonaBar(function () {
+                                            toogleUserMode('EDIT');
+                                            saveBtnEditSettings();
                                         });
                                     });
                                 } else {


### PR DESCRIPTION
Prevents PB from breaking when call to UpdateUserSettings fails.

Previously Persona Bar was wating for the call to `UpdateUserSettings` before it opened/closed. If the call failed that action was suppressed.

I changed that code with @francescorivola to be fire and forget. It will not wait for the AJAX call to finish which can mean the PB reacts quicker.