### PR TITLE
DNN-10236 reorder calls to toggle edit mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.sln.docstates
 *.local.sln
 applicationhost.config
+.vs/
 
 # Build results
 [Dd]ebug/

--- a/src/Modules/UI/Dnn.PersonaBar.UI/admin/personaBar/scripts/main.js
+++ b/src/Modules/UI/Dnn.PersonaBar.UI/admin/personaBar/scripts/main.js
@@ -475,16 +475,16 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
             return config.siteRoot || "/";
         }
 
-        function saveBtnEditSettings() {
+        function saveBtnEditSettings(success, error) {
             saveUserSetting({
                 expandPersonaBar: false,
                 activePath: null,
                 activeIdentifier: null
-            });
+            }, success, error);
         }
 
-        function saveUserSetting(settings) {
-            util.persistent.save(settings);
+        function saveUserSetting(settings, success, error) {
+            util.persistent.save(settings, success, error);
         }
 
         function inLockEditMode() {
@@ -870,16 +870,18 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
 
                                 if (config.userMode !== 'Edit') {
                                     $btnEdit.on('click', function handleEdit() {
-                                        function toogleUserMode(mode) {
+                                        function toogleUserMode(mode, successCallback) {
                                             util.sf.moduleRoot = 'internalservices';
                                             util.sf.controller = "controlBar";
-                                            util.sf.post('ToggleUserMode', { UserMode: mode }, function handleToggleUserMode() {
-                                                window.parent.location.reload();
-                                            });
+                                            util.sf.post('ToggleUserMode', { UserMode: mode }, successCallback);
                                         };
                                         util.closePersonaBar(function () {
-                                            toogleUserMode('EDIT');
-                                            saveBtnEditSettings();
+                                            toogleUserMode('EDIT', function() {
+                                                function reloadPage() {
+                                                    window.parent.location.reload();
+                                                }
+                                                saveBtnEditSettings(reloadPage, reloadPage);
+                                            });
                                         });
                                     });
                                 } else {

--- a/src/Modules/UI/Dnn.PersonaBar.UI/admin/personaBar/scripts/persistent.js
+++ b/src/Modules/UI/Dnn.PersonaBar.UI/admin/personaBar/scripts/persistent.js
@@ -21,7 +21,7 @@ define(['jquery'], function ($) {
                     if (!settings) settings = $.extend(defaultSettings, cfg.userSettings);
                     return settings;
                 },
-                save: function (s, callback) {
+                save: function (s, success, error) {
                     if (!s) return;
                     settings = $.extend(defaultSettings, s);
 
@@ -40,10 +40,10 @@ define(['jquery'], function ($) {
 
                         $.extend(cfg.userSettings, settings);
 
-                        if (typeof callback === 'function') {
-                            callback();
+                        if (typeof success === 'function') {
+                            success();
                         }
-                    });
+                    }, error);
                 }
             };
         }


### PR DESCRIPTION
Previously there was a race condition when saving profile. we changed the calls to be cascading and not concurrent

Also, added the `error` callback to `persistent` to reload the page even if the call fails.